### PR TITLE
fix(workflow-cli): do not modify the arg of after '--'

### DIFF
--- a/drycc.go
+++ b/drycc.go
@@ -192,7 +192,19 @@ Use 'git push drycc main' to deploy to an application.
 
 func removeConfigFlag(argv []string) []string {
 	var kept []string
+	var dashIndex int = -1
 	for i, arg := range argv {
+		// -- /bin/sh -c --config  condition
+		if arg == "--" {
+			kept = append(kept, arg)
+			dashIndex = i
+			continue
+		}
+		if dashIndex != -1 && dashIndex < i {
+			kept = append(kept, arg)
+			continue
+		}
+
 		if arg == "-c" || strings.HasPrefix(arg, "--config=") {
 			continue
 			// If the previous option is -c, remove the argument as well
@@ -208,6 +220,10 @@ func removeConfigFlag(argv []string) []string {
 
 func getConfigFlag(argv []string) string {
 	for i, arg := range argv {
+		// -- /bin/sh -c/ --config=  condition
+		if arg == "--" {
+			return ""
+		}
 		if strings.HasPrefix(arg, "--config=") {
 			return strings.TrimPrefix(arg, "--config=")
 		} else if i != 0 && argv[i-1] == "-c" {

--- a/drycc_test.go
+++ b/drycc_test.go
@@ -131,6 +131,24 @@ func TestGetConfigFlag(t *testing.T) {
 	}
 	actual = getConfigFlag(argv)
 	assert.Equal(t, actual, expected, "config-flag")
+
+	expected = ""
+	argv = []string{
+		"--",
+		"ipsum",
+		"--config=config",
+	}
+	actual = getConfigFlag(argv)
+	assert.Equal(t, actual, expected, "config-flag")
+
+	argv = []string{
+		"--",
+		"ipsum",
+		"-c",
+		"config",
+	}
+	actual = getConfigFlag(argv)
+	assert.Equal(t, actual, expected, "config-flag")
 }
 
 func TestRemoveConfigFlag(t *testing.T) {
@@ -153,6 +171,34 @@ func TestRemoveConfigFlag(t *testing.T) {
 		"ipsum",
 		"-c",
 		"the-config-flag",
+	}
+	actual = removeConfigFlag(argv)
+	assert.Equal(t, actual, expected, "args")
+
+	expected = []string{
+		"--",
+		"sh",
+		"-c",
+		"the-config-flag",
+	}
+	argv = []string{
+		"--",
+		"sh",
+		"-c",
+		"the-config-flag",
+	}
+	actual = removeConfigFlag(argv)
+	assert.Equal(t, actual, expected, "args")
+
+	expected = []string{
+		"--",
+		"sh",
+		"--config=the-config-flag",
+	}
+	argv = []string{
+		"--",
+		"sh",
+		"--config=the-config-flag",
 	}
 	actual = removeConfigFlag(argv)
 	assert.Equal(t, actual, expected, "args")


### PR DESCRIPTION
fix cmd as: drycc healthchecks:set readiness exec --type=celerylow -- /bin/sh -c "celery -A normandy_apollo.celery inspect ping -d celery@\${HOSTNAME}"

Error: client configuration file not found at: /root/.drycc/celery.json
Are you logged in? Use 'drycc login' or 'drycc register' to get started